### PR TITLE
GWTRAR-35: IE9 only white page: remove doctype specification html 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,15 @@
 language: java
+sudo: false
 before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
-  - "git clone https://github.com/geomajas/geomajas-build-tools target/geomajas-build-tools"
+  - "git clone https://github.com/geomajas/geomajas-build-tools target/geomajas-build-tools -q"
+  - "echo \"export MAVEN_OPTS='-Dmaven.repo.local=$HOME/.m2/repository -Xmx1024m -XX:MaxPermSize=1024m -Dgwt.compiler.localWorkers=2'\" > ~/.mavenrc"
 jdk:
   - oraclejdk7
 cache:
   directories:
   - $HOME/.m2
 install: true
-script: "mvn verify -B -V --settings target/geomajas-build-tools/settings.xml"
-env: MAVEN_OPTS="-XX:MaxPermSize=512m"
+script: 
+  - mvn verify -B -V --settings target/geomajas-build-tools/settings.xml -q

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<!DOCTYPE HTML>
 <html>
 		<!--
 		  ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.


### PR DESCRIPTION
example at http://dev.geomajas.org/geomajas-gwt-quickstart-application_GWTRAR-35_IE9whitePage/